### PR TITLE
#118009571 Fix websockets on heroku staging application

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,7 @@
   },
   "addons":[
     "heroku-postgresql",
-    "sendgrid"
+    "sendgrid",
+    "rediscloud"
   ]
 }

--- a/app/assets/javascripts/search_with_map.js
+++ b/app/assets/javascripts/search_with_map.js
@@ -4,7 +4,7 @@ var markers = []
 
 function host_name () {
   if ( location.port.length === 0 ) {
-    return location.hostname + ':3001/websocket'
+    return location.hostname + '/websocket'
   } else {
     return location.hostname + ':' + location.port + '/websocket'
   }


### PR DESCRIPTION
#### What does this PR do?

Fixes websocket connection on heroku staging application.
#### Description of Task to be completed?

Remove the default port for websockets communication (port 3001)
#### Any background context you want to provide?

The default port requirement was imposed from `websocket-rails` docs but this does not work on the staging server.
#### What are the relevant pivotal tracker stories?
#118009571
