### PR TITLE
fix (controller): replace task model with skillset model in task_mana…

### DIFF
--- a/app/controllers/task_managements_controller.rb
+++ b/app/controllers/task_managements_controller.rb
@@ -18,7 +18,8 @@ class TaskManagementsController < ApplicationController
 
   def create
     @task = TaskManagement.new(task_details.except(:task_name))
-    @task.task_id = Task.find_by(name: task_details[:task_name].capitalize).id
+    @task.task_id = Skillset.find_by(name: task_details[:task_name].capitalize).
+      id
     @task.start_time = get_time(:start)
     @task.end_time = get_time(:end)
     if @task.save

--- a/app/controllers/task_managements_controller.rb
+++ b/app/controllers/task_managements_controller.rb
@@ -19,7 +19,7 @@ class TaskManagementsController < ApplicationController
   def create
     @task = TaskManagement.new(task_details.except(:task_name))
     @task.task_id = Skillset.find_by(name: task_details[:task_name].capitalize).
-      id
+                    id
     @task.start_time = get_time(:start)
     @task.end_time = get_time(:end)
     if @task.save

--- a/app/views/pages/search_result.html.erb
+++ b/app/views/pages/search_result.html.erb
@@ -1,7 +1,7 @@
 <main>
 <section class="col m9 s12 offset-m3">
   <div class="row">
-    <% if @taskees.nil? %>
+    <% if @taskees.nil? || @taskees.empty? %>
       <div class="col m8 offset-m2 s6">
         <p>Oooops! We could not find any result matching your query. You can modify it or use one of our suggested keywords and search again.</p>
       </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,10 +96,10 @@ class SeedData
       { user_id: 3, task_id: 1 },
       { user_id: 2, task_id: 4 },
       { user_id: 5, task_id: 2 },
-      { user_id: 8, task_id: 6 },
+      { user_id: 1, task_id: 6 },
       { user_id: 7, task_id: 5 },
       { user_id: 8, task_id: 3 },
-      { user_id: 9, task_id: 2 }
+      { user_id: 4, task_id: 2 }
     ]
   end
 

--- a/spec/features/create_bid_spec.rb
+++ b/spec/features/create_bid_spec.rb
@@ -22,15 +22,15 @@ RSpec.feature "Create Task for bidding", type: :feature do
   scenario "tasker can click on biddings link and be directed to biddings\
    page" do
     click_link "Biddings"
-    expect(page).to have_selector("h1", "Bids")
-    expect(page).to have_selector("a", "add")
+    expect(page).to have_selector("h1", text: "Bids")
+    expect(page).to have_selector("a", text: "add")
   end
 
   scenario "tasker can click on add button and be redirected to an add bid\
    form" do
     click_link "Biddings"
     click_link "add"
-    expect(page).to have_selector("h2", "New Bid")
+    expect(page).to have_selector("h2", text: "New Bid")
     expect(page).to have_css("form.new_bidding")
   end
 

--- a/spec/features/taskee_skillset_spec.rb
+++ b/spec/features/taskee_skillset_spec.rb
@@ -20,14 +20,14 @@ RSpec.feature "Taskee skillset" do
 
   scenario "taskee can see a list of own skillset" do
     click_link "My Skillset"
-    expect(page).to have_selector("li.collection-item", @skillset.name)
+    expect(page).to have_selector("li.collection-item", text: @skillset.name)
   end
 
   scenario "taskee can add a new task to skillset", js: true do
     visit "/skillsets"
     fill_in "skillset_name", with: "Cleaning"
     click_button "Create Skillset"
-    expect(page).to have_selector("li.collection-item", "Cleaning")
+    expect(page).to have_selector("li.collection-item", text: "Cleaning")
   end
 
   scenario "taskee can remove task from skillset", js: true do


### PR DESCRIPTION
# [#126857003] Fixing the search for taskees result page.
#### What does this PR do?

This PR fixes the case whereby the app crashes while trying to search for taskees.
#### Description of Task to be completed?

Replace the call to search by task in task management controller to search by skillset.
#### How should this be manually tested?
- Visit the homepage of the site
- Sign in as a tasker
- Search for taskees
- A page showing the task results will be rendered
#### Any background context you want to provide?

The reason for this bug is because the former implementation searches for taskees by task. Now it has been changed to skillset.
#### What are the relevant pivotal tracker stories?

[#126857003]
