### PR TITLE
#126857003  Fix attempting to create a task after searching

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -21,8 +21,8 @@ class ChargesController < ApplicationController
     notify("taskee", @task.taskee_id)
     redirect_to dashboard_path, notice: "You have been charged successfully"\
       " and your taskee has been notified"
-  rescue Stripe::CardError => e
-    flash[:error] = e.message
-    redirect_to dashboard_path, notice: "There was an error, please try again"
+  rescue Stripe::CardError
+    redirect_to dashboard_path, danger: "There was a problem with your card"\
+      "\nTry and enter valid card details"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,6 +30,9 @@ class PagesController < ApplicationController
     if params[:searcher] || session[:searcher]
       session[:searcher] = params[:searcher] if params[:searcher]
       @taskees = get_taskees_by_search(session[:searcher])
+      skillset = Skillset.where("LOWER(name) LIKE ?",
+                                "%#{session[:searcher].downcase}%").first
+      session[:searcher] = skillset.name if skillset
     end
     render "search_result"
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -15,7 +15,7 @@ module NotificationsHelper
   end
 
   def fetch_task(object)
-    @task ||= Task.find(object.task_id)
+    @task ||= Skillset.find(object.task_id)
   end
 
   def generate_html(css_class_name, tasker_image, tasker_name, task_name, task)

--- a/spec/features/notification_of_taskees_for_tasks_spec.rb
+++ b/spec/features/notification_of_taskees_for_tasks_spec.rb
@@ -4,17 +4,17 @@ require "rails_helper"
 RSpec.describe "Notification of taskees for new tasks", type: :feature do
   let(:taskee) { create(:user, user_attr.merge(user_type: "taskee")) }
   let(:tasker) { create(:user, user_attr.merge(user_type: "tasker")) }
-  let(:task) { create(:task, task_attr) }
+  let(:skillset) { create(:skillset) }
 
   before(:each) do
     create(
       :task_management,
-      task_id: task.id,
+      task_id: skillset.id,
       taskee_id: taskee.id,
       tasker_id: tasker.id,
-      status: "inactive"
+      status: "inactive",
+      paid: true
     )
-    TaskManagement.first.update_attribute(:paid, true)
     log_in_with taskee.email, taskee.password
     visit notifications_path
     page.all(".btn")[0].click


### PR DESCRIPTION
# [#126857003] Fix attempting to create a task after searching
#### What does this PR do?

This PR fixes the issue whereby the app crashes when you attempt to create a task.
#### How should this be manually tested?

You can visit the site and create a task by first searching for a skillset.
#### Any background context you want to provide?

This bug arose as a result of the restructuring of the models related to task creation i.e `Skillset, TaskManagement and Task`
#### What are the relevant pivotal tracker stories?

**#126857003**
