### PR TITLE
#127082391 Bug: fix task assigning

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class AccountActivationsController < ApplicationController
   def confirm_email
     user = User.find_by_email(confirmation_params[:email])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/biddings_controller.rb
+++ b/app/controllers/biddings_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class BiddingsController < ApplicationController
   before_action :login_required
   before_action :set_bidding, only: [:edit, :update, :destroy]

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class ChargesController < ApplicationController
   def new
   end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -17,11 +17,24 @@ class ChargesController < ApplicationController
       currency: "usd"
     )
     @task.update_attribute(:paid, true)
-    notify("taskee", @task.taskee_id)
+    notify_taskee @task
     redirect_to dashboard_path, notice: "You have been charged successfully"\
       " and your taskee has been notified"
   rescue Stripe::CardError
     redirect_to dashboard_path, danger: "There was a problem with your card"\
       "\nTry and enter valid card details"
+  rescue Stripe::InvalidRequestError
+    redirect_to dashboard_path, notice: "An error occured while authenticating"\
+      ".\nYou have to try again"
+  end
+
+  def notify_taskee(task)
+    tasker = User.find(task.tasker_id).firstname
+    Notification.create(
+      message: "a new task from #{tasker}",
+      sender_id: task.tasker_id,
+      receiver_id: task.taskee_id,
+      notifiable: task
+    ).notify_receiver("new_task")
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class DashboardController < ApplicationController
   before_action :login_required
   before_action :show_notification_count,

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class MapController < WebsocketRails::BaseController
   def get_nearby_taskees
     taskees = get_all_taskees

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class NotificationsController < ApplicationController
   before_action :show_notification_count, only: :index
   before_action :set_notification, only: [:show, :update]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class SessionsController < ApplicationController
   before_action :guest_only, only: [:new]
 

--- a/app/controllers/skillsets_controller.rb
+++ b/app/controllers/skillsets_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class SkillsetsController < ApplicationController
   before_action :taskee_required
 

--- a/app/controllers/task_managements_controller.rb
+++ b/app/controllers/task_managements_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class TaskManagementsController < ApplicationController
   before_action :login_required, :show_notification_count,
                 only: [:index, :new, :show, :review_and_rate]

--- a/app/controllers/task_managements_controller.rb
+++ b/app/controllers/task_managements_controller.rb
@@ -24,15 +24,8 @@ class TaskManagementsController < ApplicationController
     if @task.save
       session.delete(:searcher)
       flash.clear
-      flash[:notice] = "Your taskee has been notified"
-      tasker = User.find(@task.tasker_id).firstname
-      Notification.create(
-        message: "#{@task.task.name} task from #{tasker}",
-        sender_id: @task.tasker_id,
-        receiver_id: @task.taskee_id,
-        notifiable: @task
-      ).notify_receiver("new_task")
-      redirect_to dashboard_path
+      flash.now[:notice] = "Your task has been created"
+      render "show"
     else
       retain_form_values
       redirect_to assign_task_path(obfuscate(id: @task.taskee_id))

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class TasksController < ApplicationController
   before_action :set_task, only: [:update, :show, :close_bid]
   before_action :validate_pricerange, only: :update

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class TestController < WebsocketRails::BaseController
   def foo
     # current_user.user_type == "tasker" ? notify_tasker : notify_taskee

--- a/app/controllers/user_plans_controller.rb
+++ b/app/controllers/user_plans_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class UserPlansController < ApplicationController
   before_action :check_amount, only: :create
 

--- a/app/controllers/user_profile.rb
+++ b/app/controllers/user_profile.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class UserProfile < ApplicationController
   before_action :login_required
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class UsersController < ApplicationController
   before_action :guest_only, only: [:new]
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,6 +3,23 @@ class Notification < ActiveRecord::Base
   belongs_to :receiver, class_name: "User"
   belongs_to :notifiable, polymorphic: true
 
+  def self.unnotified(user)
+    user.notifications.where(user_notified: false)
+  end
+
+  def self.unnotified_count(user_id)
+    where(receiver_id: user_id).where(user_notified: false).count
+  end
+
+  def self.unread(user)
+    user.notifications.where(read: false)
+  end
+
+  def self.update_as_notified(user)
+    user.notifications.where(user_notified: false).
+      update_all(user_notified: true)
+  end
+
   def update_as_read
     update_attribute(:read, true)
   end
@@ -22,23 +39,6 @@ class Notification < ActiveRecord::Base
 
   def notify_receiver(event_name)
     send_message(receiver_id, event_name)
-  end
-
-  def self.unnotified(user)
-    user.notifications.where(user_notified: false)
-  end
-
-  def self.unnotified_count(user_id)
-    where(receiver_id: user_id).where(user_notified: false).count
-  end
-
-  def self.unread(user)
-    user.notifications.where(read: false)
-  end
-
-  def self.update_as_notified(user)
-    user.notifications.where(user_notified: false).
-      update_all(user_notified: true)
   end
 
   def send_message(user_id, event_name)


### PR DESCRIPTION
# [#127082391] Bug: fix task assignment payments
#### What does this PR do?

This PR precludes the notification of a taskee of a given or assigned task if the task has not yet been paid for.
#### Description of Task to be completed?

This task involves moving the taskee notification functionality from the `TaskManagementsController`s `create` action to the charges controller. This ensures that a taskee will not be notified if the tasker has not yet paid.
#### How should this be manually tested?

You can simply log on to the site and create a task by assigning to a taskee directly. Instead of being redirected to your dashboard, you will be required to pay with your card. Failure to do so means the taskee will not be notified. You can pay later and then the taskee will get the notification.
#### What are the relevant pivotal tracker stories?
#127082391
