### PR TITLE
Fix dashboard menu for both Taskee and Tasker

### DIFF
--- a/app/assets/stylesheets/base/_helpers.scss
+++ b/app/assets/stylesheets/base/_helpers.scss
@@ -106,6 +106,7 @@ button.btn[disabled] {
 }
 #my-search-field {
   width: 220px;
+  border-bottom: none;
 }
 .apply{
   color: #eb4D5c !important;

--- a/app/assets/stylesheets/base/_helpers.scss
+++ b/app/assets/stylesheets/base/_helpers.scss
@@ -107,6 +107,7 @@ button.btn[disabled] {
 #my-search-field {
   width: 220px;
   border-bottom: none;
+  box-shadow: none;
 }
 .apply{
   color: #eb4D5c !important;

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -12,45 +12,35 @@
       </a>
       <ul class="right dashboard-navlinks">
         <li>
-          <% if current_user && current_user.taskee? %>
           <div class="search-bar">
+            <% if current_user && current_user.taskee? %>
             <div class="input-field my-input" id="search-input">
               <%= form_tag("/tasks/search", method: "post") do %>
               <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
-              <% end %>
             </div>
+            <% end %>
+            <% else %>
+            <div>
+              <%= form_tag("/tasks/search", method: "post") do %>
+              <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
+            </div>
+            <% end %>
           </div>
+          <% end %>
         </li>
         <li class="">
           <span class="search-icon-span left">
             <i class="material-icons search-i" id="search">search</i>
           </span>
         </li>
-        <% end %>
-        <li>
-          <% if current_user && current_user.tasker? %>
-          <div class="search-bar">
-            <div class="input-field my-input" id="search-input">
-              <%= form_tag("/tasks/search", method: "post") do %>
-              <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
-              <% end %>
-            </div>
-          </div>
-        </li>
-        <li class="">
-          <span class="search-icon-span left">
-            <i class="material-icons search-i" id="search">search</i>
-          </span>
-        </li>
-        <% end %>
         <% if @count && @count > 0 %>
         <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
         <% end %>
         <li class="notification-dropdown" data-activates="tasks">
           <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
         </li>
-        <li>
           <% if current_user.tasker? %>
+        <li>
           <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
             <i class="material-icons">rate_review</i>
           </a>
@@ -58,8 +48,8 @@
           <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
             <i class="material-icons">rate_review</i>
           </a>
-          <% end %>
         </li>
+          <% end %>
       </ul>
       <ul id="options" class="dropdown-content">
         <% if current_user.confirmed %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,63 +1,60 @@
 <% if logged_in? %>
-  <header>
-    <nav class="nav-wrapper">
-      <div class="container">
-        <%= link_to "Workdey", dashboard_path, class: "brand-logo" %>
-        <a href="#" class="right dropdown" data-activates="options">
-          <%= cl_image_tag current_user.image_url, class: "user-profile-image" %>
-          <span class="username">
-            <%= "#{current_user.firstname} #{current_user.lastname}" %>
-            <i class="fa fa-caret-down"></i>
-          </span>
-        </a>
-
-        <ul class="right dashboard-navlinks">
-          <% if @count && @count > 0 %>
-            <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
+<header>
+  <nav class="nav-wrapper">
+    <div class="container">
+      <%= link_to "Workdey", dashboard_path, class: "brand-logo" %>
+      <a href="#" class="right dropdown" data-activates="options">
+        <%= cl_image_tag current_user.image_url, class: "user-profile-image" %>
+        <span class="username">
+          <%= "#{current_user.firstname} #{current_user.lastname}" %>
+          <i class="fa fa-caret-down"></i>
+        </span>
+      </a>
+      <ul class="right dashboard-navlinks">
+        <% if @count && @count > 0 %>
+        <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
+        <% end %>
+        <li>
+          <% if current_user.tasker? %>
+          <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
+            <i class="material-icons">rate_review</i>
+          </a>
+          <% else %>
+          <!-- <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
+            <i class="material-icons">rate_review</i>
+          </a> -->
           <% end %>
-          <li>
-            <% if current_user && current_user.taskee? %>
-            <div class="search-bar">
-              <div class="input-field my-input" id="search-input">
-                <%= form_tag("/tasks/search", method: "post") do %>
-                <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
-                <% end %>
-              <% else %>
-                <%= form_tag(search_path, method: "post") do %>
-                  <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
-                <% end %>
+        </li>
+        <li class="notification-dropdown" data-activates="tasks">
+          <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
+        </li>
+        <li>
+          <% if current_user && current_user.taskee? %>
+          <div class="search-bar">
+            <div class="input-field my-input" id="search-input">
+              <%= form_tag("/tasks/search", method: "post") do %>
+              <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
               <% end %>
-              </div>
+              <% else %>
+              <%= form_tag(search_path, method: "post") do %>
+              <li class="">
+                <span class="search-icon-span left">
+                  <i class="material-icons search-i" id="search">search</i>
+                </span>
+                <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
+                <% end %>
+                <% end %>
+              </li>
             </div>
-          </li>
-          <li class="">
-
-            <span class="search-icon-span left">
-              <i class="material-icons search-i" id="search">search</i>
-            </span>
-          </li>
-          <li class="notification-dropdown" data-activates="tasks">
-            <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
-          </li>
-
-          <li>
-            <% if current_user.tasker? %>
-            <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
-                 <i class="material-icons">rate_review</i>
-            </a>
-            <% else %>
-            <!-- <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
-              <i class="material-icons">rate_review</i>
-            </a> -->
-            <% end %>
-          </li>
+          </div>
+        </li>
+        <li>
         </ul>
-
         <ul id="options" class="dropdown-content">
           <% if current_user.confirmed %>
-            <li>
-              <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
-            </li>
+          <li>
+            <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
+          </li>
           <% end %>
           <li>
             <%= link_to "Sign Out", signout_path, method: :delete, class: "waves-effect waves-light" %>
@@ -65,8 +62,8 @@
         </ul>
       </div>
     </nav>
-</header>
-<% else %>
+  </header>
+  <% else %>
   <header>
     <nav class="nav-wrapper">
       <div class="container">
@@ -82,4 +79,4 @@
       </div>
     </nav>
   </header>
-<% end %>
+  <% end %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,83 +1,85 @@
 <% if logged_in? %>
-<header>
-  <nav class="nav-wrapper">
-    <div class="container">
-      <%= link_to "Workdey", dashboard_path, class: "brand-logo" %>
-      <a href="#" class="right dropdown" data-activates="options">
-        <%= cl_image_tag current_user.image_url, class: "user-profile-image" %>
-        <span class="username">
-          <%= "#{current_user.firstname} #{current_user.lastname}" %>
-          <i class="fa fa-caret-down"></i>
-        </span>
-      </a>
-      <ul class="right dashboard-navlinks">
-        <li>
-          <div class="search-bar">
-            <% if current_user && current_user.taskee? %>
-            <div class="input-field my-input" id="search-input">
-              <%= form_tag("/tasks/search", method: "post") do %>
-              <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
-            </div>
-            <% end %>
-            <% else %>
-            <div>
-              <%= form_tag("/tasks/search", method: "post") do %>
-              <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
-            </div>
-            <% end %>
-          </div>
-          <% end %>
-        </li>
-        <li class="">
-          <span class="search-icon-span left">
-            <i class="material-icons search-i" id="search">search</i>
+  <header>
+    <nav class="nav-wrapper">
+      <div class="container">
+        <%= link_to "Workdey", dashboard_path, class: "brand-logo" %>
+        <a href="#" class="right dropdown" data-activates="options">
+          <%= cl_image_tag current_user.image_url, class: "user-profile-image" %>
+          <span class="username">
+            <%= "#{current_user.firstname} #{current_user.lastname}" %>
+            <i class="fa fa-caret-down"></i>
           </span>
-        </li>
-        <% if @count && @count > 0 %>
-        <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
-        <% end %>
-        <li class="notification-dropdown" data-activates="tasks">
-          <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
-        </li>
-          <% if current_user.tasker? %>
-        <li>
-          <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
-            <i class="material-icons">rate_review</i>
-          </a>
-          <% else %>
-          <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
-            <i class="material-icons">rate_review</i>
-          </a>
-        </li>
+        </a>
+
+        <ul class="right dashboard-navlinks">
+          <% if @count && @count > 0 %>
+            <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
           <% end %>
-      </ul>
-      <ul id="options" class="dropdown-content">
-        <% if current_user.confirmed %>
-        <li>
-          <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
-        </li>
-        <% end %>
-        <li>
-          <%= link_to "Sign Out", signout_path, method: :delete, class: "waves-effect waves-light" %>
-        </li>
-      </ul>
-    </div>
-  </nav>
+          <li>
+            <div class="search-bar">
+            <% if current_user && current_user.taskee? %>
+              <div class="input-field my-input" id="search-input">
+                <%= form_tag("/tasks/search", method: "post") do %>
+                <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
+                <% end %>
+              </div>
+              <% else %>
+                <%= form_tag(search_path, method: "post") do %>
+                  <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
+                <% end %>
+              <% end %>
+            </div>
+          </li>
+          <li class="">
+
+            <span class="search-icon-span left">
+              <i class="material-icons search-i" id="search">search</i>
+            </span>
+          </li>
+          <li class="notification-dropdown" data-activates="tasks">
+            <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
+          </li>
+
+          <li>
+            <% if current_user.tasker? %>
+            <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
+                 <i class="material-icons">rate_review</i>
+            </a>
+            <% else %>
+            <!-- <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
+              <i class="material-icons">rate_review</i>
+            </a> -->
+            <% end %>
+          </li>
+        </ul>
+
+        <ul id="options" class="dropdown-content">
+          <% if current_user.confirmed %>
+            <li>
+              <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
+            </li>
+          <% end %>
+          <li>
+            <%= link_to "Sign Out", signout_path, method: :delete, class: "waves-effect waves-light" %>
+          </li>
+        </ul>
+      </div>
+    </nav>
 </header>
 <% else %>
-<header>
-  <nav class="nav-wrapper">
-    <div class="container">
-      <%= link_to "Workdey", root_path, class: "brand-logo" %>
-      <ul class="right">
-        <li>
-          <%= link_to "BECOME A TASKEE", "#", class: "waves-effect waves-light" %>
-        </li>
-        <li>
-          <%= link_to "SIGN IN", signin_path, class: "waves-effect waves-light" %>
-        </li>
-      </ul>
-    </div>
-  </nav>
-</header>
+  <header>
+    <nav class="nav-wrapper">
+      <div class="container">
+        <%= link_to "Workdey", root_path, class: "brand-logo" %>
+        <ul class="right">
+          <li>
+            <%= link_to "BECOME A TASKEE", "#", class: "waves-effect waves-light" %>
+          </li>
+          <li>
+            <%= link_to "SIGN IN", signin_path, class: "waves-effect waves-light" %>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
 <% end %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,6 +1,6 @@
 <% if logged_in? %>
   <header>
-    <nav class="nav-wrapper">
+    <nav class="nav-wrapper" id="nav-wrapper">
       <div class="container">
         <%= link_to "Workdey", dashboard_path, class: "brand-logo" %>
         <a href="#" class="right dropdown" data-activates="options">

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -11,23 +11,6 @@
         </span>
       </a>
       <ul class="right dashboard-navlinks">
-        <% if @count && @count > 0 %>
-        <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
-        <% end %>
-        <li>
-          <% if current_user.tasker? %>
-          <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
-            <i class="material-icons">rate_review</i>
-          </a>
-          <% else %>
-          <!-- <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
-            <i class="material-icons">rate_review</i>
-          </a> -->
-          <% end %>
-        </li>
-        <li class="notification-dropdown" data-activates="tasks">
-          <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
-        </li>
         <li>
           <% if current_user && current_user.taskee? %>
           <div class="search-bar">
@@ -35,48 +18,76 @@
               <%= form_tag("/tasks/search", method: "post") do %>
               <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
               <% end %>
-              <% else %>
-              <%= form_tag(search_path, method: "post") do %>
-              <li class="">
-                <span class="search-icon-span left">
-                  <i class="material-icons search-i" id="search">search</i>
-                </span>
-                <%= text_field_tag :searcher, "", required: "required", placeholder: "Search taskees by skillset", id: "my-search-field" %>
-                <% end %>
-                <% end %>
-              </li>
             </div>
           </div>
         </li>
+        <li class="">
+          <span class="search-icon-span left">
+            <i class="material-icons search-i" id="search">search</i>
+          </span>
+        </li>
+        <% end %>
         <li>
-        </ul>
-        <ul id="options" class="dropdown-content">
-          <% if current_user.confirmed %>
-          <li>
-            <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
-          </li>
+          <% if current_user && current_user.tasker? %>
+          <div class="search-bar">
+            <div class="input-field my-input" id="search-input">
+              <%= form_tag("/tasks/search", method: "post") do %>
+              <%= text_field_tag :need, "", required: "required", placeholder: "Search by any skill", class: "", id: "my-input-field" %>
+              <% end %>
+            </div>
+          </div>
+        </li>
+        <li class="">
+          <span class="search-icon-span left">
+            <i class="material-icons search-i" id="search">search</i>
+          </span>
+        </li>
+        <% end %>
+        <% if @count && @count > 0 %>
+        <%= content_tag :li, content_tag(:span, @count), class: "notification-badge"  %>
+        <% end %>
+        <li class="notification-dropdown" data-activates="tasks">
+          <%= link_to raw("<i class='material-icons'>notifications_active</i>"), notifications_path, class: "tooltipped", data: { position: "left", delay: "50", tooltip: "Notifications" } %>
+        </li>
+        <li>
+          <% if current_user.tasker? %>
+          <a href="<%= new_task_path %>" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Task Creation">
+            <i class="material-icons">rate_review</i>
+          </a>
+          <% else %>
+          <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="Manage Tasks">
+            <i class="material-icons">rate_review</i>
+          </a>
           <% end %>
-          <li>
-            <%= link_to "Sign Out", signout_path, method: :delete, class: "waves-effect waves-light" %>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  </header>
-  <% else %>
-  <header>
-    <nav class="nav-wrapper">
-      <div class="container">
-        <%= link_to "Workdey", root_path, class: "brand-logo" %>
-        <ul class="right">
-          <li>
-            <%= link_to "BECOME A TASKEE", "#", class: "waves-effect waves-light" %>
-          </li>
-          <li>
-            <%= link_to "SIGN IN", signin_path, class: "waves-effect waves-light" %>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  </header>
-  <% end %>
+        </li>
+      </ul>
+      <ul id="options" class="dropdown-content">
+        <% if current_user.confirmed %>
+        <li>
+          <%= link_to "Update Profile", profile_path, class: "waves-effect waves-light" %>
+        </li>
+        <% end %>
+        <li>
+          <%= link_to "Sign Out", signout_path, method: :delete, class: "waves-effect waves-light" %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>
+<% else %>
+<header>
+  <nav class="nav-wrapper">
+    <div class="container">
+      <%= link_to "Workdey", root_path, class: "brand-logo" %>
+      <ul class="right">
+        <li>
+          <%= link_to "BECOME A TASKEE", "#", class: "waves-effect waves-light" %>
+        </li>
+        <li>
+          <%= link_to "SIGN IN", signin_path, class: "waves-effect waves-light" %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>
+<% end %>

--- a/spec/features/get_taskees_by_skillsets_spec.rb
+++ b/spec/features/get_taskees_by_skillsets_spec.rb
@@ -19,17 +19,29 @@ RSpec.feature "GetTaskeesBySkillsets", type: :feature do
     end
 
     scenario "tasker searches with skillsets that have taskees" do
+    within :xpath, "/html/body/header/nav" do
       find("#search").click
       fill_in "my-search-field", with: @skillset.name
       find("#my-search-field").native.send_keys(:return)
-      expect(page).to have_content @taskee.fullname
+     end
+
+      expect(page).to have_css("i#search", "search")
+      expect(page).to have_css("i.material-icons", "notifications_active")
+
       expect(page).to have_no_content @other_taskee.fullname
+      expect(page).to have_content @taskee.fullname
     end
 
     scenario "search for with skillsets that have no taskees" do
+    within :xpath, "/html/body/header/nav" do
       find("#search").click
       fill_in "my-search-field", with: "cleaning"
       find("#my-search-field").native.send_keys(:return)
+    end
+
+      expect(page).to have_css("i#search", "search")
+      expect(page).to have_css("i.material-icons", "notifications_active")
+
       expect(page).to have_no_content @other_taskee.fullname
       expect(page).to have_no_content @taskee.fullname
       expect(page).to have_content "We could not find any result matching your"\

--- a/spec/features/get_taskees_by_skillsets_spec.rb
+++ b/spec/features/get_taskees_by_skillsets_spec.rb
@@ -27,6 +27,11 @@ RSpec.feature "GetTaskeesBySkillsets", type: :feature do
         expect(page).to have_css("i#search")
         expect(page).to have_css("i.material-icons")
       end
+
+      within :xpath, '//*[@id="nav-wrapper"]/div/ul[2]' do
+        expect(page).to have_css("i#search")
+        expect(page).to have_css("i.material-icons")
+      end
       expect(page).to have_no_content @other_taskee.fullname
       expect(page).to have_content @taskee.fullname
     end
@@ -40,6 +45,12 @@ RSpec.feature "GetTaskeesBySkillsets", type: :feature do
         expect(page).to have_css("i#search")
         expect(page).to have_css("i.material-icons")
       end
+
+      within :xpath, '//*[@id="nav-wrapper"]/div/ul[2]' do
+        expect(page).to have_css("i#search")
+        expect(page).to have_css("i.material-icons")
+      end
+
       expect(page).to have_no_content @other_taskee.fullname
       expect(page).to have_no_content @taskee.fullname
       expect(page).to have_content "We could not find any result matching your"\

--- a/spec/features/get_taskees_by_skillsets_spec.rb
+++ b/spec/features/get_taskees_by_skillsets_spec.rb
@@ -19,29 +19,27 @@ RSpec.feature "GetTaskeesBySkillsets", type: :feature do
     end
 
     scenario "tasker searches with skillsets that have taskees" do
-    within :xpath, "/html/body/header/nav" do
       find("#search").click
       fill_in "my-search-field", with: @skillset.name
       find("#my-search-field").native.send_keys(:return)
-     end
 
-      expect(page).to have_css("i#search", "search")
-      expect(page).to have_css("i.material-icons", "notifications_active")
-
+      within "nav#nav-wrapper" do
+        expect(page).to have_css("i#search")
+        expect(page).to have_css("i.material-icons")
+      end
       expect(page).to have_no_content @other_taskee.fullname
       expect(page).to have_content @taskee.fullname
     end
 
     scenario "search for with skillsets that have no taskees" do
-    within :xpath, "/html/body/header/nav" do
       find("#search").click
       fill_in "my-search-field", with: "cleaning"
       find("#my-search-field").native.send_keys(:return)
-    end
 
-      expect(page).to have_css("i#search", "search")
-      expect(page).to have_css("i.material-icons", "notifications_active")
-
+      within "nav#nav-wrapper" do
+        expect(page).to have_css("i#search")
+        expect(page).to have_css("i.material-icons")
+      end
       expect(page).to have_no_content @other_taskee.fullname
       expect(page).to have_no_content @taskee.fullname
       expect(page).to have_content "We could not find any result matching your"\


### PR DESCRIPTION
#### What does this PR do?

Enables **Taskees** have access to search and view notifications
Enables **Taskers** have access to search, view notification and create new task
#### How should this be manually tested?

Login to the **workdey** app as a Tasker or Tasker. As a **Tasker** you should be able to create new task by clicking on the create new task icon on the dashboard, while as a **Taskee** you should be able to view just notification and  make general search
#### Screenshots (if appropriate)

TASKER
![image](https://cloud.githubusercontent.com/assets/14160244/17494991/14a5d972-5daf-11e6-8502-27d7c60a667e.png)

TASKEE
![image](https://cloud.githubusercontent.com/assets/14160244/17494967/fc989022-5dae-11e6-8ae7-dee5c55ea1fd.png)
