### PR TITLE
#[130349401] Rectify map loading

### DIFF
--- a/app/views/dashboard/search_with_map.html.erb
+++ b/app/views/dashboard/search_with_map.html.erb
@@ -4,6 +4,7 @@
             <div class="col m9 s12">
                 <div class="card" id="map" style='width: 100%; height: 600px;'></div>
             </div>
+            <div id="google-maps-scripts"></div>
             <div class="col m3 s12">
                 <br>
                 <span class="hidden" id="marker-location" data-longitude="<%= @current_user.longitude %>" data-latitude="<%= @current_user.latitude %>"></span>

--- a/app/views/dashboard/search_with_map.html.erb
+++ b/app/views/dashboard/search_with_map.html.erb
@@ -2,9 +2,10 @@
     <section class="main container center-align map-search">
         <div class="row">
             <div class="col m9 s12">
-                <div class="card" id="map" style='width: 100%; height: 600px;'></div>
+                <div class="card" id="map" style='width: 100%; height: 600px;'>
+                    <div id="google-maps-scripts"></div>
+                </div>
             </div>
-            <div id="google-maps-scripts"></div>
             <div class="col m3 s12">
                 <br>
                 <span class="hidden" id="marker-location" data-longitude="<%= @current_user.longitude %>" data-latitude="<%= @current_user.latitude %>"></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,10 +18,11 @@
   <%= render "partials/footer" %>
 
   <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css" %>
-  
+
   <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"  %>
   <%= stylesheet_link_tag "pickDate", "materialize.clockpicker" %>
   <%= javascript_include_tag "https://cdn.firebase.com/js/client/2.3.2/firebase.js" if current_page?(quiz_path) %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <div id="google-maps-scripts"></div>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,6 @@
   <%= render "partials/footer" %>
 
   <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css" %>
-
   <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"  %>
   <%= stylesheet_link_tag "pickDate", "materialize.clockpicker" %>
   <%= javascript_include_tag "https://cdn.firebase.com/js/client/2.3.2/firebase.js" if current_page?(quiz_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,5 @@
   <%= stylesheet_link_tag "pickDate", "materialize.clockpicker" %>
   <%= javascript_include_tag "https://cdn.firebase.com/js/client/2.3.2/firebase.js" if current_page?(quiz_path) %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
-  <div id="google-maps-scripts"></div>
 </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?

It allows the user to view a google map when they click on the `map search` button on the dashboard, or the `reload` button
#### Description of Task to be completed?

The map search page now shows a google map and reload button reloads the map correctly
#### How should this be manually tested?

Clicking on the map search button on the dashboard should show a google map
#### What are the relevant pivotal tracker stories?

`#130349401`
#### Screenshots (if appropriate)

![Screenshot](http://i.imgur.com/vZPcysk.png)

Closes #130349401
