### PR TITLE
[130388891] Bg Remove status validation on create

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,8 +47,6 @@ class User < ActiveRecord::Base
             length: { minimum: 8 },
             on: :create
 
-  validates :status, presence: true
-
   scope :artisans, -> { where(user_type: "artisan") }
 
   enum status: [:not_reviewed, :accepted, :rejected, :certified]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.delivery_method = :letter_opener
   # config.action_mailer.perform_deliveries = true
-  # config.action_mailer.default_url_options = { host: "localhost", port: "3000" }
+  config.action_mailer.default_url_options = { host: "localhost", port: "3000" }
 
   # config.action_mailer.delivery_method =  :smtp
   # config.action_mailer.smtp_settings =

--- a/config/initializers/default_attributes.rb
+++ b/config/initializers/default_attributes.rb
@@ -1,1 +1,1 @@
-DEFAULT_ATTR =  %w(password_digest created_at updated_at user_type provider oauth_id confirm_token confirmed has_taken_quiz enable_notifications longitude latitude id)
+DEFAULT_ATTR =  %w(password_digest created_at updated_at user_type provider oauth_id confirm_token confirmed has_taken_quiz enable_notifications longitude latitude id status reason)

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DashboardController, type: :controller do
       end
 
       it "returns the percentage for a artisan with skillset" do
-        expect(assigns[:completion_percentage]).to eq 85
+        expect(assigns[:completion_percentage]).to eq 82
       end
       it "returns a status code of 200" do
         expect(response.status).to eq 200

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,7 +13,6 @@ FactoryGirl.define do
     user_type "tasker"
     street_address { Faker::Address.street_address }
     status "not_reviewed"
-    reason "good"
 
     factory :user_with_tasks do
       transient do

--- a/spec/features/profile_completion_spec.rb
+++ b/spec/features/profile_completion_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Profile completion meter" do
     expect(page).to have_content "Welcome #{user.firstname}"
 
     within("div.profile-meter") do
-      expect(page).to have_content "77%"
+      expect(page).to have_content "73%"
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe "Profile completion meter" do
     log_in_with(user.email, user.password)
 
     within("div.profile-meter") do
-      expect(page).to have_content "77%"
+      expect(page).to have_content "73%"
     end
 
     click_link "Complete Your Profile"
@@ -35,7 +35,7 @@ RSpec.describe "Profile completion meter" do
     visit dashboard_path
 
     within("div.profile-meter") do
-      expect(page).to have_content "85%"
+      expect(page).to have_content "82%"
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -39,9 +39,7 @@ module Helpers
       street_address: Faker::Address.street_address,
       has_taken_quiz: true,
       confirmed: true,
-      phone: nil,
-      reason: "good",
-      status: "accepted"
+      phone: nil
     }
   end
 


### PR DESCRIPTION
#### What does this PR do?
- Removes status and reason from on create
- Adds status and reason to default attributes

Closes 
130388891
