### PR TITLE
[132788139] Bg build `session[email] not found` failure on circleci

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    selenium-webdriver (2.53.4)
+    selenium-webdriver (2.53.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
@@ -391,7 +391,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  selenium-webdriver
+  selenium-webdriver (= 2.53)
   shoulda-matchers (~> 3.1)
   sidekiq
   stripe

--- a/spec/features/share_contact_spec.rb
+++ b/spec/features/share_contact_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "Share contact", js: true do
     scenario "when tasker views the artisan details " do
       share_contact
       Capybara.reset_sessions!
-      sleep 2
       log_in_with(tasker.email, tasker.password)
       visit notifications_path
       click_on "view information"

--- a/spec/features/share_contact_spec.rb
+++ b/spec/features/share_contact_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Share contact", js: true do
     scenario "when tasker views the artisan details " do
       share_contact
       Capybara.reset_sessions!
+      visit root_path
       log_in_with(tasker.email, tasker.password)
       visit notifications_path
       click_on "view information"

--- a/spec/features/share_contact_spec.rb
+++ b/spec/features/share_contact_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Share contact", js: true do
     scenario "when tasker views the artisan details " do
       share_contact
       Capybara.reset_sessions!
-      visit root_path
+      sleep 2
       log_in_with(tasker.email, tasker.password)
       visit notifications_path
       click_on "view information"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,7 @@
 module Helpers
   def log_in_with(email, password)
     visit signin_path
-    fill_in "session[email]", with: email
+    fill_in "session_email", with: email
     fill_in "session_password", with: password
     click_button "Sign in"
   end


### PR DESCRIPTION
#### What does this PR do?
- fixes `session[email] not found` failure by using `session_email` instead of session[email]
## closes

132788139
